### PR TITLE
added GCC compatibility

### DIFF
--- a/irados/libirados.cpp
+++ b/irados/libirados.cpp
@@ -566,8 +566,8 @@ int get_next_fd() {
     // interface for POSIX Read
     irods::error irados_read_plugin(
         irods::plugin_context& _ctx,
-        void* _buf,
-        int _len) {
+        const void* _buf,
+        const int _len) {
         irods::error result = SUCCESS();
 
         irods::file_object_ptr fop = boost::dynamic_pointer_cast< irods::file_object>(_ctx.fco());
@@ -671,8 +671,8 @@ int get_next_fd() {
     // interface for POSIX Write
     irods::error irados_write_plugin(
         irods::plugin_context& _ctx,
-        void* _buf,
-        int _len) {
+        const void* _buf,
+        const int _len) {
 
         irods::error result = SUCCESS();
 

--- a/irados/libirados.cpp
+++ b/irados/libirados.cpp
@@ -566,7 +566,7 @@ int get_next_fd() {
     // interface for POSIX Read
     irods::error irados_read_plugin(
         irods::plugin_context& _ctx,
-        const void* _buf,
+        void* _buf,
         const int _len) {
         irods::error result = SUCCESS();
 
@@ -1386,7 +1386,7 @@ irods::resource* plugin_factory(const std::string& _inst_name,
     resc->add_operation(irods::RESOURCE_OP_CREATE, &irados_create_plugin);
     resc->add_operation(irods::RESOURCE_OP_OPEN, &irados_open_plugin);
     resc->add_operation<void*,int>(irods::RESOURCE_OP_READ, std::function<irods::error(irods::plugin_context&,void*,int)>(irados_read_plugin));
-    resc->add_operation<void*,int>(irods::RESOURCE_OP_WRITE, std::function<irods::error(irods::plugin_context&,void*,int)>(irados_write_plugin));
+    resc->add_operation<const void*,int>(irods::RESOURCE_OP_WRITE, std::function<irods::error(irods::plugin_context&,const void*,int)>(irados_write_plugin));
     resc->add_operation(irods::RESOURCE_OP_CLOSE, &irados_close_plugin);
     resc->add_operation(irods::RESOURCE_OP_UNLINK, &irados_unlink_plugin);
     resc->add_operation<struct stat*>(irods::RESOURCE_OP_STAT, std::function<irods::error(irods::plugin_context&, struct stat*)>(irados_stat_plugin));


### PR DESCRIPTION
Caused an boost::any_cast runtime error, since no matching function was found, when compiled with GCC. See https://github.com/irods/irods/issues/4083 for a detailed description.
Clang compatibility should be checked first.